### PR TITLE
Fix equal qualify issue when running with Python 3

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ while running:
             if event.key == pygame.K_RIGHT:
                 playerX_change = 5
             if event.key == pygame.K_SPACE:
-                if bullet_state is "ready":
+                if bullet_state == "ready":
                     bulletSound = mixer.Sound("laser.wav")
                     bulletSound.play()
                     # Get the current x cordinate of the spaceship
@@ -174,7 +174,7 @@ while running:
         bulletY = 480
         bullet_state = "ready"
 
-    if bullet_state is "fire":
+    if bullet_state == "fire":
         fire_bullet(bulletX, bulletY)
         bulletY -= bulletY_change
 


### PR DESCRIPTION
Python 3 does make `is` to `==` when matching two different values. So considering changing them make sense. 